### PR TITLE
Add unit tests for CreateOrderService validation

### DIFF
--- a/microservice-order/src/test/java/com/microservice/order/application/service/CreateOrderServiceTest.java
+++ b/microservice-order/src/test/java/com/microservice/order/application/service/CreateOrderServiceTest.java
@@ -1,0 +1,51 @@
+package com.microservice.order.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microservice.order.application.port.output.OrderItemRepository;
+import com.microservice.order.application.port.output.OrderRepository;
+import com.microservice.order.domain.model.Order;
+import com.microservice.order.domain.model.OrderItem;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateOrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @InjectMocks
+    private CreateOrderService createOrderService;
+
+    @Test
+    @DisplayName("Crear una nueva orden correctamente")
+    void createOrderSuccessfully() {
+        // Given
+        Order order = new Order(null, "1L", 1L, null);
+        OrderItem item1 = new OrderItem(null, 1L, 1L, 2, new BigDecimal("100"));
+        order.addItem(item1);
+        when(orderRepository.save(order)).thenReturn(1L);
+        when(orderItemRepository.save(1L, item1)).thenReturn(2L);
+
+        // When
+        Long orderId = createOrderService.createOrder(order);
+
+        // Then
+        assertNotNull(orderId);
+        assert(orderId.equals(1L));
+
+
+    }
+}


### PR DESCRIPTION
This pull request adds a new unit test for the `CreateOrderService` to verify that creating an order works as expected. The test uses Mockito to mock dependencies and checks that the service returns a non-null order ID when an order is created.

Testing improvements:

* Added `CreateOrderServiceTest` to test the successful creation of an order, including mocking the `OrderRepository` and `OrderItemRepository` and asserting the returned order ID.